### PR TITLE
Avoid hand  cursor for brand.

### DIFF
--- a/assets/src/less/main.less
+++ b/assets/src/less/main.less
@@ -23,7 +23,9 @@ a.brand span.logo {
     margin-bottom: -5px;
     letter-spacing: 3px;
 }
-
+a.brand {
+  cursor: default; /* Avoid hand  cursor for brand.*/
+}
 div.regex-parser-container {
     input[type='text'], label, span.quotes {
         font-family: monospace;

--- a/assets/src/less/main.less
+++ b/assets/src/less/main.less
@@ -23,9 +23,11 @@ a.brand span.logo {
     margin-bottom: -5px;
     letter-spacing: 3px;
 }
+
 a.brand {
   cursor: default; /* Avoid hand  cursor for brand.*/
 }
+
 div.regex-parser-container {
     input[type='text'], label, span.quotes {
         font-family: monospace;


### PR DESCRIPTION
If the brand Shows hand cursor, users may think its a link and click on it. To avoid this we can remove the hand cursor by setting css 

``` css
cursor: default;
```
